### PR TITLE
Don't include duplicate entries in modified_since

### DIFF
--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -253,14 +253,17 @@ class Zotero(object):
         """Iterate Entries modified since datetime."""
         sql = ITEMS_SQL + 'AND modified > ?'
         ts = dt2sqlite(dt)
+        modified_ids = []
         for row in self.conn.execute(sql, (ts,)):
+            modified_ids.append(row["id"])
             yield self._load_entry(row)
 
         # Items whose attachments have changed
         sql = MODIFIED_ATTACHMENTS_SQL
         for row in self.conn.execute(sql, (ts,)):
             log.debug('[zotero] attachment(s) modified')
-            yield self.entry(row['key'])
+            if self.entry(row['key'])["id"] not in modified_ids:
+                yield self.entry(row['key'])
 
     def all_entries(self):
         """Return all database entries."""


### PR DESCRIPTION
This fixes #4 . If an entry and its attachment are both modified, the same ID will appear twice in `modifed_since`. 