### PR TITLE
Ignore notes and attachments by typeName instead of itemTypeID

### DIFF
--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -58,7 +58,8 @@ SELECT  items.itemID AS id,
     LEFT JOIN deletedItems
         ON items.itemID = deletedItems.itemID
 -- Ignore notes and attachments
-WHERE items.itemTypeID not IN (1, 14)
+WHERE itemTypes.typeName not like '%note%'
+AND itemTypes.typeName not like '%attachment%'
 AND deletedItems.dateDeleted IS NULL
 """
 


### PR DESCRIPTION
When building `ITEMS_SQL` notes and attachments are supposed to be ignored. This is not currently the case. Using `typeName` instead of `itemTypeID` fixes this issue.  This fixes #6 .