### PR TITLE
Handle orphaned attachment parents

### DIFF
--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -283,8 +283,14 @@ class Zotero(object):
         sql = MODIFIED_ATTACHMENTS_SQL
         for row in self.conn.execute(sql, (ts,)):
             log.debug('[zotero] attachment(s) modified')
-            if self.entry(row['key'])["id"] not in modified_ids:
-                yield self.entry(row['key'])
+            key = row['key']
+            entry = self.entry(key)
+            if not entry:
+                # Orphaned attachment parent; skip but log for diagnostics
+                log.warning('[zotero] orphaned attachment parent key: %r', key)
+                continue
+            if entry["id"] not in modified_ids:
+                yield entry
 
     def all_entries(self):
         """Return all database entries."""


### PR DESCRIPTION
Guard against orphaned attachment parent keys in modified_since by logging and skipping instead of crashing.

Fixes: TypeError when attachment parent key resolves to no item.
