### PR TITLE
Read native citation keys when better-bibtex.sqlite is missing (fixes #49)

### DIFF
--- a/src/lib/zothero/betterbibtex.py
+++ b/src/lib/zothero/betterbibtex.py
@@ -72,6 +72,26 @@ class BetterBibTex(object):
                 }
         self.exists = True
 
+    @classmethod
+    def from_refkeys(cls, refkeys):
+        """Build instance from a pre-loaded ``key: citekey`` mapping.
+
+        Used when there is no separate ``better-bibtex.sqlite`` (Zotero
+        7.0.31+/8/9), where citation keys are read from a native field
+        in the main Zotero database instead.
+
+        Args:
+            refkeys (dict): ``libraryID_itemKey: citekey`` mapping.
+
+        Returns:
+            BetterBibTex: Instance backed by ``refkeys``.
+
+        """
+        obj = cls.__new__(cls)
+        obj._refkeys = refkeys
+        obj.exists = bool(refkeys)
+        return obj
+
     def citekey(self, key):
         """Return Better Bibtex citekey for Zotero item.
 

--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -151,6 +151,23 @@ SELECT itemNotes.note AS note
 WHERE itemNotes.parentItemID = ?
 """
 
+# Retrieve native Better Bibtex citation keys (Zotero 7.0.31+/8/9),
+# where citekeys are stored as a regular field in the main database
+# rather than in a separate ``better-bibtex.sqlite``.
+CITEKEYS_SQL = u"""
+SELECT  items.libraryID AS libraryID,
+        items.key AS itemKey,
+        itemDataValues.value AS citekey
+    FROM items
+    JOIN itemData
+        ON items.itemID = itemData.itemID
+    JOIN fields
+        ON itemData.fieldID = fields.fieldID
+    JOIN itemDataValues
+        ON itemData.valueID = itemDataValues.valueID
+WHERE fields.fieldName = 'citationKey'
+"""
+
 # Retrieve tags for given item
 TAGS_SQL = u"""
 SELECT tags.name AS name
@@ -203,20 +220,42 @@ class Zotero(object):
     @property
     def bbt(self):
         """Return BetterBibTex."""
-        
+
         if not self._bbt:
-            
-            self.bibpath_copy = copyifnewer(self.originalBib, self.bibpath)
-
-
             from .betterbibtex import BetterBibTex
-            
-            self._bbt = BetterBibTex(self.bibpath_copy)
-            #self._bbt = BetterBibTex(self.dbpath)
+
+            if os.path.exists(self.originalBib):
+                # Legacy layout: citekeys live in their own
+                # ``better-bibtex.sqlite`` alongside the Zotero database.
+                self.bibpath_copy = copyifnewer(self.originalBib, self.bibpath)
+                self._bbt = BetterBibTex(self.bibpath_copy)
+            else:
+                # Zotero 7.0.31+/8/9: ``better-bibtex.sqlite`` is gone and
+                # citekeys are a native field in the main database.
+                self._bbt = BetterBibTex.from_refkeys(self._native_citekeys())
+
             if self._bbt.exists:
                 log.debug('[zotero] loaded BetterBibTex data')
 
         return self._bbt
+
+    def _native_citekeys(self):
+        """Return ``libraryID_itemKey: citekey`` map from main database.
+
+        Reads the native ``citationKey`` field added in Zotero 7.0.31,
+        which replaced the separate ``better-bibtex.sqlite`` in Zotero 9.
+
+        Returns:
+            dict: ``libraryID_itemKey: citekey`` mapping.
+
+        """
+        refkeys = {}
+        for row in self.conn.execute(CITEKEYS_SQL):
+            key = u'{}_{}'.format(row['libraryID'], row['itemKey'])
+            refkeys[key] = row['citekey']
+
+        log.debug('[zotero] loaded %d native citekey(s)', len(refkeys))
+        return refkeys
 
     @property
     def last_updated(self):

--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -322,8 +322,9 @@ class Zotero(object):
         sql = MODIFIED_ATTACHMENTS_SQL
         for row in self.conn.execute(sql, (ts,)):
             log.debug('[zotero] attachment(s) modified')
-            if self.entry(row['key'])["id"] not in modified_ids:
-                yield self.entry(row['key'])
+            entry = self.entry(row['key'])
+            if entry is not None and entry['id'] not in modified_ids:
+                yield entry
 
     def all_entries(self):
         """Return all database entries."""


### PR DESCRIPTION
## Problem

Since Zotero 7.0.31, the citation key is a native Zotero field stored in the main `zotero.sqlite`, and recent Better BibTeX no longer maintains a separate `better-bibtex.sqlite` (on upgrade it is renamed to `better-bibtex.migrated`). ZotHero still unconditionally copies that file, so after upgrading to Zotero 9 every invocation fails with:

```
Error in workflow 'ZotHero'
[Errno 2] No such file or directory: '/Users/.../Zotero/better-bibtex.sqlite'
```

Fixes #49

## Fix

- `zotero.py`: when `better-bibtex.sqlite` doesn't exist, fall back to reading citekeys from the native `citationKey` field in the main Zotero database (`items` → `itemData` → `fields` → `itemDataValues`), which ZotHero already opens. The legacy path is kept, so all three eras keep working: old JSON-blob BBT, newer `citationkey`-table BBT, and Zotero 8/9 native keys.
- `betterbibtex.py`: added `BetterBibTex.from_refkeys()` so the existing `libraryID_itemKey → citekey` lookup is reused unchanged.
- `zotero.py`: guarded `modified_since()` against `entry()` returning `None` for deleted items matched by `MODIFIED_ATTACHMENTS_SQL`.

## Testing

Verified against a real Zotero 9 library (895 entries, `better-bibtex.sqlite` absent, `better-bibtex.migrated` present): all citekeys load from the native field, lookups resolve to the same keys BBT generated, and missing keys return `None`. Also smoke-tested inside the installed Alfred workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)