### PR TITLE
Add NASA ADS-style first-author search (^name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Usage
 These are the workflow's default keywords in Alfred:
 
 - `zot <query>` — Search your Zotero database (common fields).
+    - `zot ^<name>` — NASA ADS-style first-author search: only matches entries whose first author's last name starts with `<name>`, sorted by author name and year (newest first).
     - `↩` — Open the entry in Zotero. (`fn+↩` is an alternate)
     - `⌘↩` — Copy citation to the pasteboard (see [Configuration](#configuration)).
     - `⌥↩` — Copy bibliography-style citation to the pasteboard (see [Configuration](#configuration)).

--- a/src/lib/zothero/betterbibtex.py
+++ b/src/lib/zothero/betterbibtex.py
@@ -72,6 +72,26 @@ class BetterBibTex(object):
                 }
         self.exists = True
 
+    @classmethod
+    def from_refkeys(cls, refkeys):
+        """Build instance from a pre-loaded ``key: citekey`` mapping.
+
+        Used when there is no separate ``better-bibtex.sqlite`` (Zotero
+        7.0.31+/8/9), where citation keys are read from a native field
+        in the main Zotero database instead.
+
+        Args:
+            refkeys (dict): ``libraryID_itemKey: citekey`` mapping.
+
+        Returns:
+            BetterBibTex: Instance backed by ``refkeys``.
+
+        """
+        obj = cls.__new__(cls)
+        obj._refkeys = refkeys
+        obj.exists = bool(refkeys)
+        return obj
+
     def citekey(self, key):
         """Return Better Bibtex citekey for Zotero item.
 

--- a/src/lib/zothero/index.py
+++ b/src/lib/zothero/index.py
@@ -25,15 +25,16 @@ from .zotero import Entry
 # Version of the database schema/data format.
 # Increment this every time the schema or JSON format changes to
 # invalidate the existing cache.
-DB_VERSION = 8
+DB_VERSION = 9
 
 # SQL schema for the search database. The Entry is also stored in the
 # database as JSON for speed (it takes 7 SQL queries to retrieve an
 # Entry from the Zotero database).
 INDEX_SCHEMA = """
 CREATE VIRTUAL TABLE search USING fts3(
-    `id`, `title`, `year`, `creators`, `authors`, `editors`,
-    `tags`, `collections`, `attachments`, `notes`, `abstract`, `all`
+    `id`, `title`, `year`, `creators`, `authors`, `firstauthor`,
+    `editors`, `tags`, `collections`, `attachments`, `notes`,
+    `abstract`, `all`
 );
 
 CREATE TABLE modified (
@@ -73,13 +74,15 @@ PRAGMA INTEGRITY_CHECK;
 """
 
 # Search database column names
-COLUMNS = ('title', 'year', 'creators', 'authors', 'editors', 'tags',
-           'collections', 'attachments', 'notes', 'abstract', 'all')
+COLUMNS = ('title', 'year', 'creators', 'authors', 'firstauthor',
+           'editors', 'tags', 'collections', 'attachments', 'notes',
+           'abstract', 'all')
 
 # Search weightings for columns. The first column (key) is ignored (0.0)
 # collections, attachments, notes, abstract and all have lower weightings.
 # "all" is particularly low-ranked to avoid polluting results
-WEIGHTINGS = (0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.4, 0.3, 0.3, 0.1)
+WEIGHTINGS = (0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.4, 0.3, 0.3,
+              0.1)
 
 
 class InitialiseDB(Exception):
@@ -333,6 +336,14 @@ class Index(object):
                 names = {d.family for d in e.creators + e.authors + e.editors
                          if d.family}
 
+                # Family name of first author; fall back to first
+                # creator (e.g. editor of an edited volume)
+                firstauthor = u''
+                for d in e.authors or e.creators:
+                    if d.family:
+                        firstauthor = d.family
+                        break
+
                 all_ = [e.title, u' '.join(names), tags, collections,
                         attachments, notes, e.abstract, str(e.year),
                         e.date]
@@ -360,6 +371,7 @@ class Index(object):
                     str(e.year),
                     u' '.join([d.family for d in e.creators if d.family]),
                     u' '.join([d.family for d in e.authors if d.family]),
+                    firstauthor,
                     u' '.join([d.family for d in e.editors if d.family]),
                     tags,
                     collections,
@@ -375,7 +387,8 @@ class Index(object):
                     sql = u"""
                         UPDATE search
                             SET `title` = ?, `year` = ?, `creators` = ?,
-                                `authors` = ?, `editors` = ?,
+                                `authors` = ?, `firstauthor` = ?,
+                                `editors` = ?,
                                 `tags` = ?, `collections` = ?,
                                 `attachments` = ?, `notes` = ?,
                                 `abstract` = ?, `all` = ?
@@ -397,7 +410,7 @@ class Index(object):
                     # Fulltext search table
                     sql = u"""
                         INSERT INTO search
-                            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """
                     c.execute(sql, data)
 

--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -151,6 +151,23 @@ SELECT itemNotes.note AS note
 WHERE itemNotes.parentItemID = ?
 """
 
+# Retrieve native Better Bibtex citation keys (Zotero 7.0.31+/8/9),
+# where citekeys are stored as a regular field in the main database
+# rather than in a separate ``better-bibtex.sqlite``.
+CITEKEYS_SQL = u"""
+SELECT  items.libraryID AS libraryID,
+        items.key AS itemKey,
+        itemDataValues.value AS citekey
+    FROM items
+    JOIN itemData
+        ON items.itemID = itemData.itemID
+    JOIN fields
+        ON itemData.fieldID = fields.fieldID
+    JOIN itemDataValues
+        ON itemData.valueID = itemDataValues.valueID
+WHERE fields.fieldName = 'citationKey'
+"""
+
 # Retrieve tags for given item
 TAGS_SQL = u"""
 SELECT tags.name AS name
@@ -203,20 +220,42 @@ class Zotero(object):
     @property
     def bbt(self):
         """Return BetterBibTex."""
-        
+
         if not self._bbt:
-            
-            self.bibpath_copy = copyifnewer(self.originalBib, self.bibpath)
-
-
             from .betterbibtex import BetterBibTex
-            
-            self._bbt = BetterBibTex(self.bibpath_copy)
-            #self._bbt = BetterBibTex(self.dbpath)
+
+            if os.path.exists(self.originalBib):
+                # Legacy layout: citekeys live in their own
+                # ``better-bibtex.sqlite`` alongside the Zotero database.
+                self.bibpath_copy = copyifnewer(self.originalBib, self.bibpath)
+                self._bbt = BetterBibTex(self.bibpath_copy)
+            else:
+                # Zotero 7.0.31+/8/9: ``better-bibtex.sqlite`` is gone and
+                # citekeys are a native field in the main database.
+                self._bbt = BetterBibTex.from_refkeys(self._native_citekeys())
+
             if self._bbt.exists:
                 log.debug('[zotero] loaded BetterBibTex data')
 
         return self._bbt
+
+    def _native_citekeys(self):
+        """Return ``libraryID_itemKey: citekey`` map from main database.
+
+        Reads the native ``citationKey`` field added in Zotero 7.0.31,
+        which replaced the separate ``better-bibtex.sqlite`` in Zotero 9.
+
+        Returns:
+            dict: ``libraryID_itemKey: citekey`` mapping.
+
+        """
+        refkeys = {}
+        for row in self.conn.execute(CITEKEYS_SQL):
+            key = u'{}_{}'.format(row['libraryID'], row['itemKey'])
+            refkeys[key] = row['citekey']
+
+        log.debug('[zotero] loaded %d native citekey(s)', len(refkeys))
+        return refkeys
 
     @property
     def last_updated(self):

--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -322,8 +322,9 @@ class Zotero(object):
         sql = MODIFIED_ATTACHMENTS_SQL
         for row in self.conn.execute(sql, (ts,)):
             log.debug('[zotero] attachment(s) modified')
-            if self.entry(row['key'])["id"] not in modified_ids:
-                yield self.entry(row['key'])
+            entry = self.entry(row['key'])
+            if entry is not None and entry['id'] not in modified_ids:
+                yield entry
 
     def all_entries(self):
         """Return all database entries."""

--- a/src/zh.py
+++ b/src/zh.py
@@ -135,8 +135,27 @@ def do_search(query):
     if running:  # Tell Alfred to re-run the workflow
         wf.rerun = 0.2
 
+    # NASA ADS-style first-author search: "^smith" searches the
+    # firstauthor field and sorts results by author name and year
+    # (newest first) instead of by relevance
+    ads_query = query.startswith(u'^') and query[1:].strip()
+    if ads_query:
+        query = u'firstauthor:' + query[1:].strip()
+
     # Get entries matching query
     entries = app.search(query)
+
+    if ads_query:
+        def ads_key(e):
+            creators = e.authors or e.creators
+            name = u''
+            for c in creators:
+                if c.family:
+                    name = c.family.lower()
+                    break
+            return (name, -(e.year or 0))
+
+        entries.sort(key=ads_key)
 
     # ------------------------------------------------------------------
     # If no entries, show "Search XYZ" message or "no results" warning


### PR DESCRIPTION
## Feature

Adds first-author search in the style of NASA ADS's `^author` syntax:

- `zot ^smith` — matches only entries whose **first author's** last name starts with `smith` (co-authorships are excluded), with results sorted by first-author last name, then year (newest first), instead of by relevance.
- `firstauthor:smith` — the underlying FTS column is also available via the regular field syntax and is listed by the `zot:` keyword.

## Implementation

- `index.py`: new `firstauthor` FTS column holding the family name of each entry's first author (falling back to the first creator, e.g. the editor of an edited volume). `DB_VERSION` bumped to 9 so existing indexes rebuild automatically in the background.
- `zh.py`: queries starting with `^` are rewritten to `firstauthor:…` and the results re-sorted by (last name, −year). A bare `^` degrades gracefully (no crash, empty-term FTS match returns no rows).
- `README.md`: documented under the `zot` keyword.

## Testing

Verified against a real 895-entry library: `^albrecht` returns only the entry where Albrecht is first author (entries where the name appears as a co-author don't match), prefix matching works (`^al` → Alarcon, Albrecht, Allen, … correctly sorted), plain and field-scoped queries are unaffected.

## Note

Based on #50 (the Zotero 9 `better-bibtex.sqlite` fix), so that PR's two commits appear here as well; merging #50 first will reduce this to the two feature commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)