### PR TITLE
First-author search (^name) — rebased from #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Usage
 These are the workflow's default keywords in Alfred:
 
 - `zot <query>` — Search your Zotero database (common fields).
+    - `zot ^<name>` — NASA ADS-style first-author search: only matches entries whose first author's last name starts with `<name>`, sorted by author name and year (newest first).
     - `↩` — Open the entry in Zotero. (`fn+↩` is an alternate)
     - `⌘↩` — Copy citation to the pasteboard (see [Configuration](#configuration)).
     - `⌥↩` — Copy bibliography-style citation to the pasteboard (see [Configuration](#configuration)).

--- a/src/lib/zothero/index.py
+++ b/src/lib/zothero/index.py
@@ -32,8 +32,9 @@ DB_VERSION = 9
 # Entry from the Zotero database).
 INDEX_SCHEMA = """
 CREATE VIRTUAL TABLE search USING fts3(
-    `id`, `title`, `year`, `creators`, `authors`, `editors`,
-    `tags`, `collections`, `attachments`, `notes`, `abstract`, `all`
+    `id`, `title`, `year`, `creators`, `authors`, `firstauthor`,
+    `editors`, `tags`, `collections`, `attachments`, `notes`,
+    `abstract`, `all`
 );
 
 CREATE TABLE modified (
@@ -73,13 +74,15 @@ PRAGMA INTEGRITY_CHECK;
 """
 
 # Search database column names
-COLUMNS = ('title', 'year', 'creators', 'authors', 'editors', 'tags',
-           'collections', 'attachments', 'notes', 'abstract', 'all')
+COLUMNS = ('title', 'year', 'creators', 'authors', 'firstauthor',
+           'editors', 'tags', 'collections', 'attachments', 'notes',
+           'abstract', 'all')
 
 # Search weightings for columns. The first column (key) is ignored (0.0)
 # collections, attachments, notes, abstract and all have lower weightings.
 # "all" is particularly low-ranked to avoid polluting results
-WEIGHTINGS = (0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.4, 0.3, 0.3, 0.1)
+WEIGHTINGS = (0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.4, 0.3, 0.3,
+              0.1)
 
 
 class InitialiseDB(Exception):
@@ -358,6 +361,14 @@ class Index(object):
                 names = {d.family for d in e.creators + e.authors + e.editors
                          if d.family}
 
+                # Family name of first author; fall back to first
+                # creator (e.g. editor of an edited volume)
+                firstauthor = u''
+                for d in e.authors or e.creators:
+                    if d.family:
+                        firstauthor = d.family
+                        break
+
                 all_ = [e.title, u' '.join(names), tags, collections,
                         attachments, notes, e.abstract, str(e.year),
                         e.date]
@@ -385,6 +396,7 @@ class Index(object):
                     str(e.year),
                     u' '.join([d.family for d in e.creators if d.family]),
                     u' '.join([d.family for d in e.authors if d.family]),
+                    firstauthor,
                     u' '.join([d.family for d in e.editors if d.family]),
                     tags,
                     collections,
@@ -400,7 +412,8 @@ class Index(object):
                     sql = u"""
                         UPDATE search
                             SET `title` = ?, `year` = ?, `creators` = ?,
-                                `authors` = ?, `editors` = ?,
+                                `authors` = ?, `firstauthor` = ?,
+                                `editors` = ?,
                                 `tags` = ?, `collections` = ?,
                                 `attachments` = ?, `notes` = ?,
                                 `abstract` = ?, `all` = ?
@@ -422,7 +435,7 @@ class Index(object):
                     # Fulltext search table
                     sql = u"""
                         INSERT INTO search
-                            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """
                     c.execute(sql, data)
 

--- a/src/lib/zothero/index.py
+++ b/src/lib/zothero/index.py
@@ -25,7 +25,8 @@ from .zotero import Entry
 # Version of the database schema/data format.
 # Increment this every time the schema or JSON format changes to
 # invalidate the existing cache.
-DB_VERSION = 9
+# 10: added the `firstauthor` FTS column (v2.5.0 shipped 9).
+DB_VERSION = 10
 
 # SQL schema for the search database. The Entry is also stored in the
 # database as JSON for speed (it takes 7 SQL queries to retrieve an

--- a/src/zh.py
+++ b/src/zh.py
@@ -136,8 +136,27 @@ def do_search(query):
     if running:  # Tell Alfred to re-run the workflow
         wf.rerun = 0.2
 
+    # NASA ADS-style first-author search: "^smith" searches the
+    # firstauthor field and sorts results by author name and year
+    # (newest first) instead of by relevance
+    ads_query = query.startswith(u'^') and query[1:].strip()
+    if ads_query:
+        query = u'firstauthor:' + query[1:].strip()
+
     # Get entries matching query
     entries = app.search(query)
+
+    if ads_query:
+        def ads_key(e):
+            creators = e.authors or e.creators
+            name = u''
+            for c in creators:
+                if c.family:
+                    name = c.family.lower()
+                    break
+            return (name, -(e.year or 0))
+
+        entries.sort(key=ads_key)
 
     # ------------------------------------------------------------------
     # If no entries, show "Search XYZ" message or "no results" warning


### PR DESCRIPTION
First-author search in the style of NASA ADS's `^author` syntax:

- `zot ^smith` — matches only entries whose **first author's** last name starts
  with `smith` (co-authors excluded), sorted by first-author surname then year
  (newest first) instead of by relevance.
- The underlying `firstauthor` FTS column is also reachable as `firstauthor:…`.

## Provenance
This is @zhouconghao's feature from #51, **cherry-picked here with authorship
preserved** (commits `Add firstauthor search field` and `Add NASA ADS-style
first-author search syntax`). #51 was stacked on the Zotero-9 native-citekey fix
(#50), which already shipped independently in v2.5.0 (#54), so those base
commits are dropped here — this PR is just the two feature commits, rebased onto
the post-2.5.0 `master`.

## One adjustment
`DB_VERSION` is bumped to **10** (the original targeted 8→9, but v2.5.0 already
ships 9). 10 forces existing indexes to rebuild so the new `firstauthor` column
is populated.

## Verification (real library)
- `^scheet` returns only the entry where Scheet is the first author.
- `^s` prefix-matches and sorts by surname.
- A bare `^` degrades gracefully (no crash).
- Index rebuilds automatically on first run after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
