### PR TITLE
Open entry PDF in Zotero reader (config option) — closes #44, #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ These are the workflow's default keywords in Alfred:
 - `zot <query>` — Search your Zotero database (common fields).
     - `zot ^<name>` — NASA ADS-style first-author search: only matches entries whose first author's last name starts with `<name>`, sorted by author name and year (newest first).
     - `↩` — Open the entry in Zotero. (`fn+↩` is an alternate)
+        - If `OPEN_PDF` is enabled in the configuration sheet, `↩` instead opens the entry's PDF in Zotero's built-in reader (entries without a PDF still select in Zotero). `fn+↩` then selects the item, and on entries you didn't open with `↩`, `fn+↩` offers "Open PDF in Zotero".
     - `⌘↩` — Copy citation to the pasteboard (see [Configuration](#configuration)).
     - `⌥↩` — Copy bibliography-style citation to the pasteboard (see [Configuration](#configuration)).
     - `⇧↩` — View entry attachments (if present).
@@ -201,6 +202,7 @@ You probably shouldn't edit the `CITE_STYLE` or `LOCALE` variables yourself, as 
 | `LOCALE`           | Locale for citations. Default: `en-US` (US English).                    |
 | `ZOTERO_DIR`       | Path to your Zotero data. Read from Zotero's config by default.         |
 | `COPY_CITEKEY_MOD` | Set to copy Better BibTeX citekey instead of CSL citation/bibliography. |
+| `OPEN_PDF`         | When enabled, `↩` opens the entry's PDF in Zotero's reader instead of selecting the item. |
 
 
 

--- a/src/info.plist
+++ b/src/info.plist
@@ -2796,6 +2796,23 @@ These are the workflow's default keywords in Alfred:
 			<key>variable</key>
 			<string>ATTACHMENTS_DIR</string>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<false/>
+				<key>text</key>
+				<string>Open the entry’s PDF in Zotero’s reader on ↩ (instead of selecting the item)</string>
+			</dict>
+			<key>description</key>
+			<string>Items without a PDF still select in Zotero. The other action is always available on the fn modifier.</string>
+			<key>label</key>
+			<string>Open PDF in Zotero</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>OPEN_PDF</string>
+		</dict>
 	</array>
 	<key>variablesdontexport</key>
 	<array/>

--- a/src/lib/zothero/index.py
+++ b/src/lib/zothero/index.py
@@ -26,7 +26,8 @@ from .zotero import Entry
 # Increment this every time the schema or JSON format changes to
 # invalidate the existing cache.
 # 10: added the `firstauthor` FTS column (v2.5.0 shipped 9).
-DB_VERSION = 10
+# 11: added `library_path` to entry JSON (for zotero://open-pdf links).
+DB_VERSION = 11
 
 # SQL schema for the search database. The Entry is also stored in the
 # database as JSON for speed (it takes 7 SQL queries to retrieve an

--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -187,7 +187,8 @@ class Zotero(object):
         self.live_dbpath = live_dbpath or self.dbpath
         self._conn = None
         self._bbt = None  # BetterBibTex
-        
+        self._library_paths = None  # libraryID -> zotero:// path segment
+
         self.originalBib = os.path.join(datadir, 'better-bibtex.sqlite')
         self.bibpath = os.path.join(self.WF_CACHE, 'better-bibtex.sqlite')
         
@@ -365,7 +366,36 @@ class Zotero(object):
         # Better Bibtex citekey
         e.citekey = self.bbt.citekey('{}_{}'.format(e.library, e.key))
 
+        # Zotero URI path segment for this entry's library, e.g. ``library``
+        # for the personal library or ``groups/<groupID>`` for a group
+        # library. Used to build ``zotero://open-pdf`` links.
+        e.library_path = self.library_paths.get(e.library, u'library')
+
         return e
+
+    @property
+    def library_paths(self):
+        """Map ``libraryID`` to its ``zotero://`` URI path segment.
+
+        The personal library is ``library``; group libraries are
+        ``groups/<groupID>``. ``zotero://open-pdf`` URIs need this form
+        (unlike ``zotero://select``, which accepts ``<libraryID>_<key>``).
+
+        Returns:
+            dict: ``{libraryID: path_segment}`` for group libraries.
+
+        """
+        if self._library_paths is None:
+            self._library_paths = {}
+            try:
+                for row in self.conn.execute(
+                        'SELECT libraryID, groupID FROM groups'):
+                    self._library_paths[row['libraryID']] = \
+                        u'groups/{}'.format(row['groupID'])
+            except sqlite3.OperationalError:
+                pass
+
+        return self._library_paths
 
     def _entry_attachments(self, entry_id):
         """Fetch attachments for an entry."""

--- a/src/zh.py
+++ b/src/zh.py
@@ -60,6 +60,9 @@ CITE_STYLE = os.getenv('CITE_STYLE')
 # User's preferred locale for citations
 LOCALE = os.getenv('LOCALE')
 COPY_CITEKEY_MOD = os.getenv('COPY_CITEKEY_MOD')
+# When enabled, ↩ opens the entry's PDF in Zotero's reader instead of
+# selecting the item in Zotero.
+OPEN_PDF = os.getenv('OPEN_PDF') == '1'
 
 
 
@@ -101,6 +104,24 @@ def do_fields(query):
 
     wf.warn_empty('No matching columns', 'Try a different query?')
     wf.send_feedback()
+
+
+def pdf_open_url(entry):
+    """Return a ``zotero://open-pdf`` URL for the entry's first PDF.
+
+    Args:
+        entry (zothero.zotero.Entry): Entry to inspect.
+
+    Returns:
+        unicode or None: ``zotero://open-pdf/...`` URL opening the entry's
+        first PDF attachment in Zotero's reader, or ``None`` if it has none.
+
+    """
+    for att in entry.attachments:
+        if att.path and att.path.lower().endswith('.pdf'):
+            libpath = entry.get('library_path') or u'library'
+            return u'zotero://open-pdf/{}/items/{}'.format(libpath, att.key)
+    return None
 
 
 def do_search(query):
@@ -190,7 +211,14 @@ def do_search(query):
         f = EntryFormatter(e)
         sub = u'{} {}'.format(f.creators, f.year)
         key = u'{}_{}'.format(e.library, e.key)
-        url = u'zotero://select/items/' + key
+        select_url = u'zotero://select/items/' + key
+
+        # If OPEN_PDF is enabled and the entry has a PDF attachment, open it
+        # directly in Zotero's reader; otherwise fall back to selecting the
+        # item. The other action is always offered on the fn modifier.
+        pdf_url = pdf_open_url(e)
+        url = pdf_url if (OPEN_PDF and pdf_url) else select_url
+
         if e.attachments:
             sub += u' Attachments: ' + str(len(e.attachments))
 
@@ -239,10 +267,18 @@ def do_search(query):
         mod = it.add_modifier('ctrl', 'View all citation formats')
         mod.setvar('action', 'show-citations')
 
-        # Alternative open-in-zotero key with fn
-        mod = it.add_modifier('fn', 'Open in Zotero')
+        # fn offers whichever open action ↩ didn't take, so both selecting
+        # the item and opening its PDF in Zotero are always reachable.
+        if OPEN_PDF and pdf_url:
+            mod = it.add_modifier('fn', 'Select in Zotero')
+            mod.setvar('url', select_url)
+        elif pdf_url:
+            mod = it.add_modifier('fn', 'Open PDF in Zotero')
+            mod.setvar('url', pdf_url)
+        else:
+            mod = it.add_modifier('fn', 'Open in Zotero')
+            mod.setvar('url', select_url)
         mod.setvar('action', 'open-in-zotero')
-        mod.setvar('url', url)
         mod.setvar('id', e.id)
 
         # ------------------------------------------------------------------


### PR DESCRIPTION
Implements the feature requested in #44 and #47: open an entry's PDF directly
in Zotero's built-in reader, instead of only selecting the item.

## Behaviour
- New **`OPEN_PDF`** checkbox in the configuration sheet (off by default).
- When **on**: `↩` opens the entry's first PDF via
  `zotero://open-pdf/<library>/items/<attachmentKey>`; entries with no PDF
  still select. `fn+↩` selects the item.
- When **off** (unchanged default): `↩` selects in Zotero; if the entry has a
  PDF, `fn+↩` offers "Open PDF in Zotero".
- So both actions are always reachable, and nobody's existing muscle memory
  changes unless they opt in.

## Notes
- **Group libraries supported**: `library_paths` maps `libraryID` →
  `library` or `groups/<groupID>` (the `open-pdf` URI needs the group form,
  unlike `select`). Verified against a real group library.
- `DB_VERSION` 10 → 11 so existing indexes rebuild and carry the new
  `library_path` field.
- First PDF attachment wins; non-PDF attachments (snapshots, links) are skipped.

## Verification
- `pdf_open_url()` unit-tested: personal → `…/library/items/KEY`, group →
  `…/groups/389188/items/KEY`, no-PDF → `None`, picks first PDF over HTML.
- Real group mapping resolves to `{2: 'groups/389188'}`.
- ⚠️ Not yet smoke-tested against a live Zotero with an actual PDF (my test
  library has no attachments) — the URI scheme is Zotero's documented one,
  but a quick manual check in Alfred is worth doing before release.

Closes #44, closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
